### PR TITLE
Promote Jenkins release-tag support from dev to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,18 +18,35 @@ pipeline {
     stage('Checkout') {
       steps {
         script {
-          def normalizedInput = (env.BRANCH_TAG ?: env.BRANCH_NAME ?: 'dev')
+          def configuredBranchTag = env.BRANCH_TAG?.trim()
+          def rawSelector = (env.TAG_NAME ?: env.BRANCH_NAME ?: configuredBranchTag ?: 'dev').trim()
+          def normalizedInput = rawSelector
             .toLowerCase()
-            .replaceAll(/[^a-z0-9._-]+/, '-')
+            .replaceAll(/[^a-z0-9._/-]+/, '-')
+          def releaseTag = null
 
-          if (normalizedInput == 'main') {
+          if (rawSelector.startsWith('refs/tags/')) {
+            releaseTag = rawSelector.replaceFirst(/^refs\/tags\//, '')
+          } else if (rawSelector ==~ /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/) {
+            releaseTag = rawSelector
+          } else if ((env.APP_VERSION ?: '').trim() ==~ /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/) {
+            releaseTag = env.APP_VERSION.trim()
+          }
+
+          if (releaseTag) {
+            env.BRANCH_TAG = 'prod'
+            env.SCM_BRANCH = "refs/tags/${releaseTag}"
+            env.APP_VERSION = (env.APP_VERSION ?: releaseTag).trim()
+          } else if (normalizedInput == 'main') {
             env.BRANCH_TAG = 'prod'
             env.SCM_BRANCH = 'main'
           } else {
-            env.BRANCH_TAG = normalizedInput
+            env.BRANCH_TAG = (configuredBranchTag ?: normalizedInput)
+              .toLowerCase()
+              .replaceAll(/[^a-z0-9._-]+/, '-')
 
             if (!(env.BRANCH_TAG in ['dev', 'test', 'prod'])) {
-              error("BRANCH_TAG must be one of: dev, test, prod. A branch build of 'main' is treated as 'prod'.")
+              error("BRANCH_TAG must be one of: dev, test, prod. A branch build of 'main' or a release tag like 'refs/tags/v1.0.0' is treated as 'prod'.")
             }
 
             env.SCM_BRANCH = env.BRANCH_TAG == 'prod' ? 'main' : env.BRANCH_TAG
@@ -38,7 +55,7 @@ pipeline {
 
         checkout([
           $class: 'GitSCM',
-          branches: [[name: "*/${env.SCM_BRANCH}"]],
+          branches: [[name: env.SCM_BRANCH.startsWith('refs/tags/') ? env.SCM_BRANCH : "*/${env.SCM_BRANCH}"]],
           doGenerateSubmoduleConfigurations: false,
           extensions: scm.extensions ?: [],
           submoduleCfg: [],

--- a/README.md
+++ b/README.md
@@ -627,10 +627,12 @@ Create these Jenkins pipeline environment variables:
     - `test` -> `test`
     - `prod` -> `main`
   - If Jenkins builds the actual SCM branch named `main` and `BRANCH_TAG` is not overridden, the pipeline automatically treats it as `prod`
+  - If Jenkins builds a Git tag ref such as `refs/tags/v1.0.0`, the pipeline automatically treats it as `prod`
 - `APP_VERSION`
   - Optional release version such as `v0.3.0`
   - If set, Jenkins also tags and pushes `${DOCKER_IMAGE_REPOSITORY}:${APP_VERSION}`
   - If not set, the image still includes immutable Git SHA metadata and pushes the Git SHA tag
+  - For release-tag builds, the pipeline automatically derives `APP_VERSION` from the Git tag when the selector is something like `refs/tags/v1.0.0`
 - `MAILGUN_DOMAIN`
   - Mailgun sending domain
   - Example: `mg.tjrcade.com`
@@ -710,6 +712,23 @@ If you create separate Jenkins jobs for each environment, set `BRANCH_TAG` per j
 
 When `BRANCH_TAG=prod`, the pipeline checks out `main` from SCM and still tags the container as `prod`.
 When Jenkins directly builds the SCM branch named `main`, the pipeline also treats that build as `prod` automatically.
+When Jenkins directly builds a Git tag such as `refs/tags/v1.0.0`, the pipeline treats that build as `prod`, checks out the tag itself, and uses `v1.0.0` as `APP_VERSION`.
+
+#### Release Tag Build Configuration
+
+For production releases built from Git tags on `main`, configure the Jenkins job or multibranch/tag discovery to build the tag ref directly.
+
+- Branch specifier / ref:
+  - `refs/tags/v1.0.0`
+- Expected pipeline behavior:
+  - treats the build as `prod`
+  - checks out `refs/tags/v1.0.0`
+  - derives `APP_VERSION=v1.0.0`
+  - pushes:
+    - `${DOCKER_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}:prod`
+    - `${DOCKER_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}:v1.0.0`
+    - `${DOCKER_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}:${short_git_sha}`
+- Future release tags such as `refs/tags/v1.0.1` and `refs/tags/v1.1.0` follow the same flow automatically.
 
 #### Resulting Image Tags
 


### PR DESCRIPTION
## Summary
This PR promotes the latest `dev` changes to `main`, focused on Jenkins production release handling for Git tags.

## Included Changes
- support Jenkins builds triggered from tag refs such as `refs/tags/v1.0.0`
- automatically treat release-tag builds as `prod`
- automatically derive `APP_VERSION` from the Git tag for release builds
- keep existing `dev`, `test`, `prod`, and `main` branch behavior unchanged
- update README Jenkins documentation for tag-based production builds

## Release Flow
After this PR is merged:
- create or recreate the production release tag on `main`
- configure Jenkins release jobs to build refs like `refs/tags/v1.0.0`
- the pipeline will publish `prod`, semantic version, and SHA image tags

## Verification
- Jenkinsfile checkout and tag-handling logic updated
- README Jenkins configuration updated to document release tag builds
