### PR TITLE
Promote Jenkins tag-selector fix from dev to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
           def rawSelector = (env.TAG_NAME ?: env.BRANCH_NAME ?: configuredBranchTag ?: 'dev').trim()
           def normalizedInput = rawSelector
             .toLowerCase()
-            .replaceAll(/[^a-z0-9._/-]+/, '-')
+            .replaceAll("[^a-z0-9._/-]+", '-')
           def releaseTag = null
 
           if (rawSelector.startsWith('refs/tags/')) {


### PR DESCRIPTION
## Summary
This PR promotes the latest `dev` changes to `main` to fix Jenkins release-tag build parsing.

## Included Changes
- fixes Groovy parsing for the Jenkins tag selector normalization logic
- preserves support for `refs/tags/v1.0.0` style production release builds
- keeps release-tag builds mapped to `prod`
- keeps automatic `APP_VERSION` derivation from Git release tags

## Verification
- Jenkinsfile syntax issue corrected in the tag selector normalization code
- production tag-build flow remains documented in the README

## Release Follow-up
After this PR is merged, retag `main` as `v1.0.0` so the production release tag includes this Jenkins fix.
