### PR TITLE
Promote Jenkins checked-ref classification from dev to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,8 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
+        checkout(scm)
+
         script {
           def configuredBranchTag = env.BRANCH_TAG?.trim()
           def scmSelector = ''
@@ -30,12 +32,19 @@ pipeline {
           def normalizedInput = rawSelector
             .toLowerCase()
             .replaceAll("[^a-z0-9._/-]+", '-')
+          def detectedReleaseTag = sh(
+            script: 'git describe --tags --exact-match 2>/dev/null || true',
+            returnStdout: true
+          ).trim()
           def releaseTag = null
 
           env.RELEASE_TAG = ''
           env.RELEASE_SOURCE_BRANCH = ''
+          env.SCM_BRANCH = rawSelector
 
-          if (rawSelector.startsWith('refs/tags/')) {
+          if (detectedReleaseTag ==~ /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/) {
+            releaseTag = detectedReleaseTag
+          } else if (rawSelector.startsWith('refs/tags/')) {
             releaseTag = rawSelector.replaceFirst(/^refs\/tags\//, '')
           } else if (rawSelector ==~ /^v\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/) {
             releaseTag = rawSelector
@@ -47,32 +56,24 @@ pipeline {
             env.BRANCH_TAG = 'prod'
             env.RELEASE_TAG = releaseTag
             env.RELEASE_SOURCE_BRANCH = 'main'
-            env.SCM_BRANCH = "refs/tags/${releaseTag}"
             env.APP_VERSION = (env.APP_VERSION ?: releaseTag).trim()
-          } else if (normalizedInput == 'main') {
+          } else if (
+            normalizedInput == 'main' ||
+            normalizedInput == '*/main' ||
+            normalizedInput == 'prod'
+          ) {
             env.BRANCH_TAG = 'prod'
-            env.SCM_BRANCH = 'main'
+          } else if (
+            normalizedInput == 'test' ||
+            normalizedInput == '*/test'
+          ) {
+            env.BRANCH_TAG = 'test'
           } else {
-            env.BRANCH_TAG = (configuredBranchTag ?: normalizedInput)
-              .toLowerCase()
-              .replaceAll(/[^a-z0-9._-]+/, '-')
-
-            if (!(env.BRANCH_TAG in ['dev', 'test', 'prod'])) {
-              error("BRANCH_TAG must be one of: dev, test, prod. A branch build of 'main' or a release tag like 'refs/tags/v1.0.0' is treated as 'prod'.")
-            }
-
-            env.SCM_BRANCH = env.BRANCH_TAG == 'prod' ? 'main' : env.BRANCH_TAG
+            env.BRANCH_TAG = 'dev'
           }
-        }
 
-        checkout([
-          $class: 'GitSCM',
-          branches: [[name: env.SCM_BRANCH.startsWith('refs/tags/') ? env.SCM_BRANCH : "*/${env.SCM_BRANCH}"]],
-          doGenerateSubmoduleConfigurations: false,
-          extensions: scm.extensions ?: [],
-          submoduleCfg: [],
-          userRemoteConfigs: scm.userRemoteConfigs
-        ])
+          echo "Build selector raw='${rawSelector}', scm='${scmSelector}', branch='${env.BRANCH_NAME ?: ''}', tag='${env.TAG_NAME ?: ''}', detected_release_tag='${detectedReleaseTag}', branch_tag='${env.BRANCH_TAG}'"
+        }
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Do not use a bind mount like:
 
 - The repository includes a `Jenkinsfile` that:
   1. checks out the SCM branch or release tag selected by Jenkins
+     - the pipeline trusts the actual Jenkins SCM checkout rather than reconstructing the ref separately
   2. validates that release-tag builds come from `main`
   3. builds the application container from `Dockerfile`
   4. runs Brakeman SAST and writes the scanner output into `reports/` in the repository workspace
@@ -644,7 +645,7 @@ Create these Jenkins pipeline environment variables:
     - `prod` -> `main`
   - If Jenkins builds the actual SCM branch named `main` and `BRANCH_TAG` is not overridden, the pipeline automatically treats it as `prod`
   - If Jenkins builds a Git tag ref such as `refs/tags/v1.0.0`, the pipeline automatically treats it as `prod`
-  - For tag-triggered jobs, the pipeline prefers the actual SCM ref from Jenkins over both `BRANCH_NAME` and any default `BRANCH_TAG` value so a branch-level default like `dev` does not override `refs/tags/v1.0.0`
+  - For tag-triggered jobs, the pipeline classifies the build from the actual checked-out Git state so a branch-level default like `dev` does not override `refs/tags/v1.0.0`
 - `APP_VERSION`
   - Optional release version such as `v0.3.0`
   - If set, Jenkins also tags and pushes `${DOCKER_IMAGE_REPOSITORY}:${APP_VERSION}`


### PR DESCRIPTION
## Summary
This PR promotes the latest `dev` changes to `main` for the next production release.

## Included Changes
- classify Jenkins builds from the actual checked-out SCM ref
- ensure tag-triggered Jenkins jobs use the checked-out Git state rather than a reconstructed branch assumption
- preserve production tag behavior for release refs such as `refs/tags/v1.0.4`
- retain release-tag validation against `main`

## Release Notes
- intended next production tag: `v1.0.4`
- release-tag Jenkins builds should now correctly detect and publish versioned production tags from the checked-out ref

## Verification
- Jenkinsfile updated to use `checkout(scm)` and detect release tags from the actual workspace state
- README updated to document the checked-out-ref classification behavior
