### PR TITLE
Promote Jenkins release tag version persistence from dev to main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,16 +112,17 @@ pipeline {
             script: 'git rev-parse HEAD',
             returnStdout: true
           ).trim()
-          env.APP_VERSION = (env.APP_VERSION ?: sh(
+          env.EFFECTIVE_APP_VERSION = (env.RELEASE_TAG ?: env.APP_VERSION ?: sh(
             script: 'git describe --tags --exact-match 2>/dev/null || true',
             returnStdout: true
           ).trim()) ?: ''
+          env.APP_VERSION = env.EFFECTIVE_APP_VERSION
           env.APP_BUILD_TIMESTAMP = sh(
             script: 'date -u +%Y-%m-%dT%H:%M:%SZ',
             returnStdout: true
           ).trim()
           env.IMAGE_URI = "${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE_REPOSITORY}"
-          env.RELEASE_IMAGE_TAG = (env.BRANCH_TAG == 'prod' && env.APP_VERSION?.trim()) ? "prod-${env.APP_VERSION}" : ''
+          env.RELEASE_IMAGE_TAG = (env.BRANCH_TAG == 'prod' && env.EFFECTIVE_APP_VERSION?.trim()) ? "prod-${env.EFFECTIVE_APP_VERSION}" : ''
         }
 
         sh '''
@@ -131,14 +132,14 @@ pipeline {
             --build-arg APP_BUILD_ENVIRONMENT="${BRANCH_TAG:-dev}" \
             --build-arg APP_BUILD_NUMBER="${BUILD_NUMBER:-local}" \
             --build-arg APP_BUILD_TIMESTAMP="${APP_BUILD_TIMESTAMP:-unknown}" \
-            --build-arg APP_VERSION="${APP_VERSION:-}" \
+            --build-arg APP_VERSION="${EFFECTIVE_APP_VERSION:-}" \
             --build-arg APP_GIT_SHA="${GIT_SHA_FULL:-unknown}" \
             --tag "${IMAGE_URI}:${GIT_SHA_SHORT:-unknown}" \
             --tag "${IMAGE_URI}:${BRANCH_TAG:-dev}" \
             .
 
-          if [ -n "${APP_VERSION:-}" ]; then
-            docker tag "${IMAGE_URI}:${GIT_SHA_SHORT:-unknown}" "${IMAGE_URI}:${APP_VERSION}"
+          if [ -n "${EFFECTIVE_APP_VERSION:-}" ]; then
+            docker tag "${IMAGE_URI}:${GIT_SHA_SHORT:-unknown}" "${IMAGE_URI}:${EFFECTIVE_APP_VERSION}"
           fi
 
           if [ -n "${RELEASE_IMAGE_TAG:-}" ]; then
@@ -181,8 +182,8 @@ pipeline {
             echo "${DOCKER_PASSWORD}" | docker login "${DOCKER_REGISTRY}" --username "${DOCKER_USERNAME}" --password-stdin
             docker push "${IMAGE_URI}:${GIT_SHA_SHORT:-unknown}"
             docker push "${IMAGE_URI}:${BRANCH_TAG:-dev}"
-            if [ -n "${APP_VERSION:-}" ]; then
-              docker push "${IMAGE_URI}:${APP_VERSION}"
+            if [ -n "${EFFECTIVE_APP_VERSION:-}" ]; then
+              docker push "${IMAGE_URI}:${EFFECTIVE_APP_VERSION}"
             fi
             if [ -n "${RELEASE_IMAGE_TAG:-}" ]; then
               docker push "${IMAGE_URI}:${RELEASE_IMAGE_TAG}"
@@ -199,8 +200,8 @@ pipeline {
       sh '''
         set +e
         docker image rm "${IMAGE_URI}:${GIT_SHA_SHORT:-unknown}" "${IMAGE_URI}:${BRANCH_TAG:-dev}" >/dev/null 2>&1 || true
-        if [ -n "${APP_VERSION:-}" ]; then
-          docker image rm "${IMAGE_URI}:${APP_VERSION}" >/dev/null 2>&1 || true
+        if [ -n "${EFFECTIVE_APP_VERSION:-}" ]; then
+          docker image rm "${IMAGE_URI}:${EFFECTIVE_APP_VERSION}" >/dev/null 2>&1 || true
         fi
         if [ -n "${RELEASE_IMAGE_TAG:-}" ]; then
           docker image rm "${IMAGE_URI}:${RELEASE_IMAGE_TAG}" >/dev/null 2>&1 || true
@@ -210,8 +211,8 @@ pipeline {
     success {
       script {
         def pushedTags = ["${IMAGE_URI}:${env.GIT_SHA_SHORT}", "${IMAGE_URI}:${env.BRANCH_TAG}"]
-        if (env.APP_VERSION?.trim()) {
-          pushedTags << "${env.IMAGE_URI}:${env.APP_VERSION}"
+        if (env.EFFECTIVE_APP_VERSION?.trim()) {
+          pushedTags << "${env.IMAGE_URI}:${env.EFFECTIVE_APP_VERSION}"
         }
         if (env.RELEASE_IMAGE_TAG?.trim()) {
           pushedTags << "${env.IMAGE_URI}:${env.RELEASE_IMAGE_TAG}"

--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ Create these Jenkins pipeline environment variables:
   - If set, Jenkins also tags and pushes `${DOCKER_IMAGE_REPOSITORY}:${APP_VERSION}`
   - If not set, the image still includes immutable Git SHA metadata and pushes the Git SHA tag
   - For release-tag builds, the pipeline automatically derives `APP_VERSION` from the Git tag when the selector is something like `refs/tags/v1.0.0`
+  - For release-tag builds, the published Docker version tag comes from the checked-out Git tag even if no explicit Jenkins environment variable is set
 - `MAILGUN_DOMAIN`
   - Mailgun sending domain
   - Example: `mg.tjrcade.com`


### PR DESCRIPTION
## Summary
This PR promotes the latest `dev` changes to `main` for the next production release.

## Included Changes
- persist the checked-out release tag version across Jenkins build and push stages
- ensure tag-triggered production builds publish the semantic version Docker tag consistently
- keep publishing:
  - `prod`
  - semantic version tag such as `v1.0.5`
  - combined production version tag such as `prod-v1.0.5`
  - immutable Git SHA tag
- update README documentation for release-tag-driven Docker version publishing

## Release Notes
- intended next production tag: `v1.0.5`
- release builds from refs like `refs/tags/v1.0.5` should now consistently publish the Docker version tag from the checked-out Git tag

## Verification
- Jenkinsfile updated to carry an effective release version through build, push, cleanup, and final output
- README updated to document the behavior
