### PR TITLE
Promote Active Storage config fix from dev to main

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,7 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>


### PR DESCRIPTION
## Summary
This PR promotes the latest `dev` changes to the production branch (`main`) for the next release.

## Included Changes
- add `config/storage.yml`
- restore required Active Storage disk service configuration for Rails 8 production boot
- fix container startup failure in production where Rails aborts because `config.active_storage.service` is configured but `config/storage.yml` is missing

## Release Notes
- intended next production tag: `v1.0.6`
- production container builds after this merge should boot without the Active Storage configuration error

## Verification
- `config/storage.yml` now defines `local` and `test` disk services
- this addresses the runtime error:
  - `Couldn't find Active Storage configuration in /app/config/storage.yml`
